### PR TITLE
feat(Goal): Apply audit recommendations to USDXBridgeAlt and OzUSDV2

### DIFF
--- a/src/L1/USDXBridgeAlt.sol
+++ b/src/L1/USDXBridgeAlt.sol
@@ -134,7 +134,7 @@ contract USDXBridgeAlt is Ownable, ReentrancyGuard {
         if (_amount == 0) revert ZeroAmount();
         if (_to == address(0)) revert ZeroAddress();
         if (!allowlisted[_stablecoin]) revert StablecoinNotAccepted();
-        uint256 bridgeAmount = _getBridgeAmount(_stablecoin, _amount);
+        uint256 bridgeAmount = getBridgeAmount(_stablecoin, _amount);
         if (bridgeAmount == 0) revert BridgeAmountTooSmall();
         if (_minAmount > bridgeAmount) revert InvalidMinAmount();
         if (totalBridged[_stablecoin] + _amount > depositCap[_stablecoin]) {
@@ -214,7 +214,7 @@ contract USDXBridgeAlt is Ownable, ReentrancyGuard {
     /// @param  _amount The amount of the stablecoin deposited.
     /// @return uint256 The amount of USDX to mint given the deposited stablecoin amount.
     /// @dev    Assumes 1:1 conversion between the deposited stablecoin and USDX.
-    function _getBridgeAmount(address _stablecoin, uint256 _amount) internal view returns (uint256) {
+    function getBridgeAmount(address _stablecoin, uint256 _amount) public view returns (uint256) {
         uint8 depositDecimals = IERC20Decimals(_stablecoin).decimals();
         uint8 usdxDecimals = l1USDX.decimals();
 

--- a/src/L1/USDXBridgeAlt.sol
+++ b/src/L1/USDXBridgeAlt.sol
@@ -120,6 +120,7 @@ contract USDXBridgeAlt is Ownable, ReentrancyGuard {
         require(_to != address(0), "USDX Bridge: Cannot bridge to the zero address.");
         require(allowlisted[_stablecoin], "USDX Bridge: Stablecoin not accepted.");
         uint256 bridgeAmount = _getBridgeAmount(_stablecoin, _amount);
+        require(bridgeAmount > 0, "USDX Bridge: Bridge amount too small.");
         require(
             totalBridged[_stablecoin] + _amount <= depositCap[_stablecoin],
             "USDX Bridge: Bridge amount exceeds deposit cap."

--- a/src/L1/USDXBridgeAlt.sol
+++ b/src/L1/USDXBridgeAlt.sol
@@ -122,7 +122,7 @@ contract USDXBridgeAlt is Ownable, ReentrancyGuard {
         require(allowlisted[_stablecoin], "USDX Bridge: Stablecoin not accepted.");
         uint256 bridgeAmount = _getBridgeAmount(_stablecoin, _amount);
         require(
-            totalBridged[_stablecoin] + bridgeAmount <= depositCap[_stablecoin],
+            totalBridged[_stablecoin] + _amount <= depositCap[_stablecoin],
             "USDX Bridge: Bridge amount exceeds deposit cap."
         );
         /// Update state
@@ -132,7 +132,7 @@ contract USDXBridgeAlt is Ownable, ReentrancyGuard {
             IERC20Decimals(_stablecoin).balanceOf(address(this)) - balanceBefore == _amount,
             "USDX Bridge: Fee-on-transfer tokens not supported."
         );
-        totalBridged[_stablecoin] += bridgeAmount;
+        totalBridged[_stablecoin] += _amount;
         // Mint USDX
         l1USDX.mint(address(this), bridgeAmount);
         /// Bridge USDX via LZ
@@ -166,7 +166,7 @@ contract USDXBridgeAlt is Ownable, ReentrancyGuard {
 
     /// @notice This function allows the owner to modify the deposit cap for deposited stablecoins.
     /// @param  _stablecoin The stablecoin address to modify the deposit cap.
-    /// @param  _newDepositCap The new deposit cap.
+    /// @param  _newDepositCap The new deposit cap in the native decimals of the stablecoin.
     function setDepositCap(address _stablecoin, uint256 _newDepositCap) external onlyOwner {
         depositCap[_stablecoin] = _newDepositCap;
         emit DepositCapSet(_stablecoin, _newDepositCap);

--- a/src/L1/USDXBridgeAlt.sol
+++ b/src/L1/USDXBridgeAlt.sol
@@ -203,7 +203,14 @@ contract USDXBridgeAlt is Ownable, ReentrancyGuard {
     function _getBridgeAmount(address _stablecoin, uint256 _amount) internal view returns (uint256) {
         uint8 depositDecimals = IERC20Decimals(_stablecoin).decimals();
         uint8 usdxDecimals = l1USDX.decimals();
-        return (_amount * 10 ** usdxDecimals) / (10 ** depositDecimals);
+
+        if (usdxDecimals == depositDecimals) {
+            return _amount;
+        } else if (usdxDecimals > depositDecimals) {
+            return _amount * (10 ** (usdxDecimals - depositDecimals));
+        } else {
+            return _amount / (10 ** (depositDecimals - usdxDecimals));
+        }
     }
 
     /// @notice Updates the gas limit for lzReceive execution on the destination chain.

--- a/src/L1/USDXBridgeAlt.sol
+++ b/src/L1/USDXBridgeAlt.sol
@@ -7,7 +7,6 @@ import {ReentrancyGuard} from "openzeppelin/contracts/security/ReentrancyGuard.s
 import {
     SendParam, OFTReceipt, MessagingReceipt, MessagingFee
 } from "@layerzero/oapp/contracts/oft/interfaces/IOFT.sol";
-import {MessagingFee} from "@layerzero/oapp/contracts/oapp/OApp.sol";
 import {OptionsBuilder} from "@layerzero/oapp/contracts/oapp/libs/OptionsBuilder.sol";
 import {IERC20Decimals} from "src/L1/interfaces/IERC20Decimals.sol";
 import {IUSDX} from "src/L1/interfaces/IUSDX.sol";

--- a/src/L2/OzUSDV2.sol
+++ b/src/L2/OzUSDV2.sol
@@ -16,6 +16,7 @@ contract OzUSDV2 is ERC4626, ReentrancyGuard, Pausable, Ownable {
 
     // Custom Errors
     error InsufficientInitialShares();
+    error ZeroAmount();
 
     /// @notice The total number of USDX held by this contract that has been deposited legitmately.
     uint256 public totalDeposited;
@@ -106,6 +107,7 @@ contract OzUSDV2 is ERC4626, ReentrancyGuard, Pausable, Ownable {
     /// @notice Distributes the yield to the protocol by updating the total pooled USDX balance.
     /// @param _amount The amount of USDX to deposit and evenly distribute to ozUSD holders.
     function distributeYield(uint256 _amount) external nonReentrant onlyOwner {
+        if (_amount == 0) revert ZeroAmount();
         uint256 previousTotal = totalDeposited;
         IERC20Metadata(asset()).safeTransferFrom(msg.sender, address(this), _amount);
         totalDeposited += _amount;

--- a/src/L2/OzUSDV2.sol
+++ b/src/L2/OzUSDV2.sol
@@ -66,8 +66,8 @@ contract OzUSDV2 is ERC4626, ReentrancyGuard, Pausable, Ownable {
     }
 
     /// @dev See {IERC4626-totalAssets}.
-    /// @notice Returns the total amount of USDX deposited in the vault (excluding yield).
-    /// @return The total amount of assets deposited by users.
+    /// @notice Returns the total amount of USDX in the vault, including both user deposits and distributed yield.
+    /// @return The total amount of assets in the vault.
     function totalAssets() public view override returns (uint256) {
         return totalDeposited;
     }

--- a/src/L2/OzUSDV2.sol
+++ b/src/L2/OzUSDV2.sol
@@ -103,9 +103,10 @@ contract OzUSDV2 is ERC4626, ReentrancyGuard, Pausable, Ownable {
     /// @notice Distributes the yield to the protocol by updating the total pooled USDX balance.
     /// @param _amount The amount of USDX to deposit and evenly distribute to ozUSD holders.
     function distributeYield(uint256 _amount) external nonReentrant onlyOwner {
+        uint256 previousTotal = totalDeposited;
         IERC20Metadata(asset()).safeTransferFrom(msg.sender, address(this), _amount);
         totalDeposited += _amount;
-        emit YieldDistributed(totalAssets() - _amount, totalAssets());
+        emit YieldDistributed(previousTotal, totalDeposited);
     }
 
     /// @notice This function allows the owner to pause or unpause this contract.

--- a/src/L2/OzUSDV2.sol
+++ b/src/L2/OzUSDV2.sol
@@ -94,8 +94,8 @@ contract OzUSDV2 is ERC4626, ReentrancyGuard, Pausable, Ownable {
         internal
         override
     {
-        super._withdraw(_caller, _receiver, _owner, _assets, _shares);
         totalDeposited -= _assets;
+        super._withdraw(_caller, _receiver, _owner, _assets, _shares);
     }
 
     /// OWNER ///

--- a/src/L2/OzUSDV2.sol
+++ b/src/L2/OzUSDV2.sol
@@ -14,6 +14,9 @@ import {Ownable} from "openzeppelin/contracts/access/Ownable.sol";
 contract OzUSDV2 is ERC4626, ReentrancyGuard, Pausable, Ownable {
     using SafeERC20 for IERC20Metadata;
 
+    // Custom Errors
+    error InsufficientInitialShares();
+
     /// @notice The total number of USDX held by this contract that has been deposited legitmately.
     uint256 public totalDeposited;
 
@@ -31,7 +34,7 @@ contract OzUSDV2 is ERC4626, ReentrancyGuard, Pausable, Ownable {
         ERC20("Ozean USD", "ozUSD")
     {
         _transferOwnership(_owner);
-        require(_sharesAmount >= 1e18, "OzUSD: Must deploy with at least one USDX.");
+        if (_sharesAmount < 1e18) revert InsufficientInitialShares();
         mint(_sharesAmount, address(0xdead));
     }
 
@@ -94,8 +97,8 @@ contract OzUSDV2 is ERC4626, ReentrancyGuard, Pausable, Ownable {
         internal
         override
     {
-        super._withdraw(_caller, _receiver, _owner, _assets, _shares);
         totalDeposited -= _assets;
+        super._withdraw(_caller, _receiver, _owner, _assets, _shares);
     }
 
     /// OWNER ///

--- a/src/L2/OzUSDV2.sol
+++ b/src/L2/OzUSDV2.sol
@@ -113,4 +113,38 @@ contract OzUSDV2 is ERC4626, ReentrancyGuard, Pausable, Ownable {
     function setPaused(bool _set) external onlyOwner {
         _set ? _pause() : _unpause();
     }
+
+
+
+    /// @notice Returns the maximum amount of assets that can be deposited for the `receiver`.
+    /// @dev Overrides the ERC4626 implementation to return 0 when the contract is paused.
+    /// @param receiver The address of the receiver.
+    /// @return Maximum amount of assets that can be deposited. Returns 0 when paused.
+    function maxDeposit(address receiver) public view override returns (uint256) {
+        return paused() ? 0 : super.maxDeposit(receiver);
+    }
+
+    /// @notice Returns the maximum amount of shares that can be minted for the `receiver`.
+    /// @dev Overrides the ERC4626 implementation to return 0 when the contract is paused.
+    /// @param receiver The address of the receiver.
+    /// @return Maximum amount of shares that can be minted. Returns 0 when paused.
+    function maxMint(address receiver) public view override returns (uint256) {
+        return paused() ? 0 : super.maxMint(receiver);
+    }
+
+    /// @notice Returns the maximum amount of assets that can be withdrawn by `owner`.
+    /// @dev Overrides the ERC4626 implementation to return 0 when the contract is paused.
+    /// @param owner The address of the owner.
+    /// @return Maximum amount of assets that can be withdrawn. Returns 0 when paused.
+    function maxWithdraw(address owner) public view override returns (uint256) {
+        return paused() ? 0 : super.maxWithdraw(owner);
+    }
+
+    /// @notice Returns the maximum amount of shares that can be redeemed by `owner`.
+    /// @dev Overrides the ERC4626 implementation to return 0 when the contract is paused.
+    /// @param owner The address of the owner.
+    /// @return Maximum amount of shares that can be redeemed. Returns 0 when paused.
+    function maxRedeem(address owner) public view override returns (uint256) {
+        return paused() ? 0 : super.maxRedeem(owner);
+    }
 }

--- a/src/L2/OzUSDV2.sol
+++ b/src/L2/OzUSDV2.sol
@@ -124,33 +124,33 @@ contract OzUSDV2 is ERC4626, ReentrancyGuard, Pausable, Ownable {
 
     /// @notice Returns the maximum amount of assets that can be deposited for the `receiver`.
     /// @dev Overrides the ERC4626 implementation to return 0 when the contract is paused.
-    /// @param receiver The address of the receiver.
+    /// @param _receiver The address of the receiver.
     /// @return Maximum amount of assets that can be deposited. Returns 0 when paused.
-    function maxDeposit(address receiver) public view override returns (uint256) {
-        return paused() ? 0 : super.maxDeposit(receiver);
+    function maxDeposit(address _receiver) public view override returns (uint256) {
+        return paused() ? 0 : super.maxDeposit(_receiver);
     }
 
     /// @notice Returns the maximum amount of shares that can be minted for the `receiver`.
     /// @dev Overrides the ERC4626 implementation to return 0 when the contract is paused.
-    /// @param receiver The address of the receiver.
+    /// @param _receiver The address of the receiver.
     /// @return Maximum amount of shares that can be minted. Returns 0 when paused.
-    function maxMint(address receiver) public view override returns (uint256) {
-        return paused() ? 0 : super.maxMint(receiver);
+    function maxMint(address _receiver) public view override returns (uint256) {
+        return paused() ? 0 : super.maxMint(_receiver);
     }
 
     /// @notice Returns the maximum amount of assets that can be withdrawn by `owner`.
     /// @dev Overrides the ERC4626 implementation to return 0 when the contract is paused.
-    /// @param owner The address of the owner.
+    /// @param _owner The address of the owner.
     /// @return Maximum amount of assets that can be withdrawn. Returns 0 when paused.
-    function maxWithdraw(address owner) public view override returns (uint256) {
-        return paused() ? 0 : super.maxWithdraw(owner);
+    function maxWithdraw(address _owner) public view override returns (uint256) {
+        return paused() ? 0 : super.maxWithdraw(_owner);
     }
 
     /// @notice Returns the maximum amount of shares that can be redeemed by `owner`.
     /// @dev Overrides the ERC4626 implementation to return 0 when the contract is paused.
-    /// @param owner The address of the owner.
+    /// @param _owner The address of the owner.
     /// @return Maximum amount of shares that can be redeemed. Returns 0 when paused.
-    function maxRedeem(address owner) public view override returns (uint256) {
-        return paused() ? 0 : super.maxRedeem(owner);
+    function maxRedeem(address _owner) public view override returns (uint256) {
+        return paused() ? 0 : super.maxRedeem(_owner);
     }
 }

--- a/test/L1/USDXBridgeAltForkTest.t.sol
+++ b/test/L1/USDXBridgeAltForkTest.t.sol
@@ -55,7 +55,7 @@ contract USDXBridgeAltForkMainetTest is TestSetup {
         uint256[] memory depositCaps = new uint256[](2);
         depositCaps[0] = 1e30;
         depositCaps[1] = 1e30;
-        vm.expectRevert("USDX Bridge: Stablecoins array length must equal the Deposit Caps array length.");
+        vm.expectRevert(USDXBridgeAlt.InvalidArrayLength.selector);
         usdxBridgeAlt = new USDXBridgeAlt(hexTrust, address(usdx), eid, stablecoins, depositCaps);
 
         /// Zero address
@@ -67,7 +67,7 @@ contract USDXBridgeAltForkMainetTest is TestSetup {
         depositCaps[0] = 1e30;
         depositCaps[1] = 1e30;
         depositCaps[2] = 1e30;
-        vm.expectRevert("USDX Bridge: Zero address.");
+        vm.expectRevert(USDXBridgeAlt.ZeroAddress.selector);
         usdxBridgeAlt = new USDXBridgeAlt(hexTrust, address(usdx), eid, stablecoins, depositCaps);
     }
 
@@ -77,21 +77,21 @@ contract USDXBridgeAltForkMainetTest is TestSetup {
         /// Non-accepted stablecoin/ERC20
         uint256 _amount = 100e18;
         TestERC20Decimals usde = new TestERC20Decimals(18);
-        vm.expectRevert("USDX Bridge: Stablecoin not accepted.");
+        vm.expectRevert(USDXBridgeAlt.StablecoinNotAccepted.selector);
         usdxBridgeAlt.bridge(address(usde), _amount, alice);
 
         /// Deposit zero
-        vm.expectRevert("USDX Bridge: May not bridge nothing.");
+        vm.expectRevert(USDXBridgeAlt.ZeroAmount.selector);
         usdxBridgeAlt.bridge(address(dai), 0, alice);
 
         /// Deposit Cap exceeded
         uint256 excess = usdxBridgeAlt.depositCap(address(dai)) + 1;
-        vm.expectRevert("USDX Bridge: Bridge amount exceeds deposit cap.");
+        vm.expectRevert(USDXBridgeAlt.ExceedsDepositCap.selector);
         usdxBridgeAlt.bridge(address(dai), excess, alice);
 
         /// Insufficient LZ fee passed
         usdc.approve(address(usdxBridgeAlt), 100e6);
-        vm.expectRevert("USDX Bridge: Layer Zero fee.");
+        vm.expectRevert(USDXBridgeAlt.InsufficientLayerZeroFee.selector);
         usdxBridgeAlt.bridge{value: 0}(address(usdc), 100e6, alice);
 
         vm.stopPrank();
@@ -105,10 +105,10 @@ contract USDXBridgeAltForkMainetTest is TestSetup {
         usdxBridgeAlt.setAllowlist(address(feeOnTransfer), true);
         usdxBridgeAlt.setDepositCap(address(feeOnTransfer), 1e30);
 
-        vm.expectRevert("USDX Bridge: Fee-on-transfer tokens not supported.");
+        vm.expectRevert(USDXBridgeAlt.FeeOnTransferTokenNotSupported.selector);
         usdxBridgeAlt.bridge(address(feeOnTransfer), 1 ether, hexTrust);
 
-        vm.expectRevert("USDX Bridge: Cannot bridge to the zero address.");
+        vm.expectRevert(USDXBridgeAlt.ZeroAddress.selector);
         usdxBridgeAlt.bridge(address(feeOnTransfer), 1 ether, address(0));
     }
 

--- a/test/L1/USDXBridgeAltForkTest.t.sol
+++ b/test/L1/USDXBridgeAltForkTest.t.sol
@@ -117,17 +117,13 @@ contract USDXBridgeAltForkMainetTest is TestSetup {
         uint256 _amount = 100e6;
         usdc.approve(address(usdxBridgeAlt), _amount);
 
-        // Assumes _amount is in a 6-decimal token (e.g., USDC) and USDX has 18 decimals.
-        // Converts to 18-decimal units by multiplying by 10^12 (18 - 6).
-        uint256 usdxAmount = _amount * (10 ** 12);
-
         uint256 aliceBalanceBefore = address(alice).balance;
         uint256 bridgeBalanceBefore = address(usdxBridgeAlt).balance;
 
         /// Bridge
         usdxBridgeAlt.bridge{value: 0.01 ether}(address(usdc), _amount, alice);
 
-        assertEq(usdxBridgeAlt.totalBridged(address(usdc)), usdxAmount);
+        assertEq(usdxBridgeAlt.totalBridged(address(usdc)), _amount);
 
         uint256 aliceBalanceAfter = address(alice).balance;
         uint256 bridgeBalanceAfter = address(usdxBridgeAlt).balance;
@@ -144,14 +140,11 @@ contract USDXBridgeAltForkMainetTest is TestSetup {
         /// Mint and approve
         uint256 _amount = 100e6;
         IERC20Alt(address(usdt)).approve(address(usdxBridgeAlt), _amount);
-        // Assumes _amount is in a 6-decimal token (e.g., USDT) and USDX has 18 decimals.
-        // Converts to 18-decimal units by multiplying by 10^12 (18 - 6).
-        uint256 usdxAmount = _amount * (10 ** 12);
 
         /// Bridge
         usdxBridgeAlt.bridge{value: 0.01 ether}(address(usdt), _amount, alice);
 
-        assertEq(usdxBridgeAlt.totalBridged(address(usdt)), usdxAmount);
+        assertEq(usdxBridgeAlt.totalBridged(address(usdt)), _amount);
     }
 
     function testBridgeUSDXWithDAI() public prank(alice) {

--- a/test/L1/USDXBridgeAltForkTest.t.sol
+++ b/test/L1/USDXBridgeAltForkTest.t.sol
@@ -78,21 +78,21 @@ contract USDXBridgeAltForkMainetTest is TestSetup {
         uint256 _amount = 100e18;
         TestERC20Decimals usde = new TestERC20Decimals(18);
         vm.expectRevert(USDXBridgeAlt.StablecoinNotAccepted.selector);
-        usdxBridgeAlt.bridge(address(usde), _amount, alice);
+        usdxBridgeAlt.bridge(address(usde), _amount, _amount, alice);
 
         /// Deposit zero
         vm.expectRevert(USDXBridgeAlt.ZeroAmount.selector);
-        usdxBridgeAlt.bridge(address(dai), 0, alice);
+        usdxBridgeAlt.bridge(address(dai), 0, 0, alice);
 
         /// Deposit Cap exceeded
         uint256 excess = usdxBridgeAlt.depositCap(address(dai)) + 1;
         vm.expectRevert(USDXBridgeAlt.ExceedsDepositCap.selector);
-        usdxBridgeAlt.bridge(address(dai), excess, alice);
+        usdxBridgeAlt.bridge(address(dai), excess, excess, alice);
 
         /// Insufficient LZ fee passed
         usdc.approve(address(usdxBridgeAlt), 100e6);
         vm.expectRevert(USDXBridgeAlt.InsufficientLayerZeroFee.selector);
-        usdxBridgeAlt.bridge{value: 0}(address(usdc), 100e6, alice);
+        usdxBridgeAlt.bridge{value: 0}(address(usdc), 100e6, 100e6, alice);
 
         vm.stopPrank();
         vm.startPrank(hexTrust);
@@ -106,10 +106,10 @@ contract USDXBridgeAltForkMainetTest is TestSetup {
         usdxBridgeAlt.setDepositCap(address(feeOnTransfer), 1e30);
 
         vm.expectRevert(USDXBridgeAlt.FeeOnTransferTokenNotSupported.selector);
-        usdxBridgeAlt.bridge(address(feeOnTransfer), 1 ether, hexTrust);
+        usdxBridgeAlt.bridge(address(feeOnTransfer), 1 ether, 1 ether, hexTrust);
 
         vm.expectRevert(USDXBridgeAlt.ZeroAddress.selector);
-        usdxBridgeAlt.bridge(address(feeOnTransfer), 1 ether, address(0));
+        usdxBridgeAlt.bridge(address(feeOnTransfer), 1 ether, 1 ether, address(0));
     }
 
     function testBridgeUSDXWithUSDC() public prank(alice) {
@@ -121,7 +121,7 @@ contract USDXBridgeAltForkMainetTest is TestSetup {
         uint256 bridgeBalanceBefore = address(usdxBridgeAlt).balance;
 
         /// Bridge
-        usdxBridgeAlt.bridge{value: 0.01 ether}(address(usdc), _amount, alice);
+        usdxBridgeAlt.bridge{value: 0.01 ether}(address(usdc), _amount, _amount, alice);
 
         assertEq(usdxBridgeAlt.totalBridged(address(usdc)), _amount);
 
@@ -142,7 +142,7 @@ contract USDXBridgeAltForkMainetTest is TestSetup {
         IERC20Alt(address(usdt)).approve(address(usdxBridgeAlt), _amount);
 
         /// Bridge
-        usdxBridgeAlt.bridge{value: 0.01 ether}(address(usdt), _amount, alice);
+        usdxBridgeAlt.bridge{value: 0.01 ether}(address(usdt), _amount, _amount, alice);
 
         assertEq(usdxBridgeAlt.totalBridged(address(usdt)), _amount);
     }
@@ -153,7 +153,7 @@ contract USDXBridgeAltForkMainetTest is TestSetup {
         dai.approve(address(usdxBridgeAlt), _amount);
 
         /// Bridge
-        usdxBridgeAlt.bridge{value: 0.01 ether}(address(dai), _amount, alice);
+        usdxBridgeAlt.bridge{value: 0.01 ether}(address(dai), _amount, _amount, alice);
 
         assertEq(usdxBridgeAlt.totalBridged(address(dai)), _amount);
     }
@@ -262,7 +262,7 @@ contract USDXBridgeAltForkMainetTest is TestSetup {
         usdc.approve(address(usdxBridgeAlt), _amount);
 
         /// Alice bridges
-        usdxBridgeAlt.bridge{value: 0.01 ether}(address(usdc), _amount, alice);
+        usdxBridgeAlt.bridge{value: 0.01 ether}(address(usdc), _amount, _amount, alice);
 
         /// Owner withdraws deposited USDC
         vm.stopPrank();

--- a/test/L2/OzUSDV2ForkTest.t.sol
+++ b/test/L2/OzUSDV2ForkTest.t.sol
@@ -36,12 +36,16 @@ contract OzUSDV2ForkTest is TestSetup {
         assertEq(l2USDX.balanceOf(address(ozUSDV2)), 1e18);
         assertEq(ozUSDV2.convertToAssets(amount), amount);
 
-        /// Owner only
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert(
+            "AccessControl: account 0xef211076b8d8b46797e09c9a374fb4cdc1df0916 is missing role 0x30cc2fcab974a5a2540213c549fc919ac7160838938e5a3a04b40906b512611a"
+        );
         ozUSDV2.distributeYield(1e18);
 
         vm.stopPrank();
         vm.startPrank(hexTrust);
+
+        // Grant YIELD_DISTRIBUTOR_ROLE to hexTrust
+        ozUSDV2.grantRole(ozUSDV2.YIELD_DISTRIBUTOR_ROLE(), hexTrust);
 
         /// Allowance
         vm.expectRevert("ERC20: insufficient allowance");
@@ -77,6 +81,9 @@ contract OzUSDV2ForkTest is TestSetup {
         vm.startPrank(hexTrust);
 
         l2USDX.approve(address(ozUSDV2), _amountB);
+
+        // Grant YIELD_DISTRIBUTOR_ROLE to hexTrust
+        ozUSDV2.grantRole(ozUSDV2.YIELD_DISTRIBUTOR_ROLE(), hexTrust);
 
         vm.expectEmit(true, true, true, true);
         emit OzUSDV2.YieldDistributed(1e18 + _amountA, 1e18 + _amountA + _amountB);
@@ -126,6 +133,9 @@ contract OzUSDV2ForkTest is TestSetup {
 
         l2USDX.approve(address(ozUSDV2), _amountB);
 
+        // Grant YIELD_DISTRIBUTOR_ROLE to hexTrust
+        ozUSDV2.grantRole(ozUSDV2.YIELD_DISTRIBUTOR_ROLE(), hexTrust);
+
         vm.expectEmit(true, true, true, true);
         emit OzUSDV2.YieldDistributed(1e18 + _amountA, 1e18 + _amountA + _amountB);
         ozUSDV2.distributeYield(_amountB);
@@ -164,6 +174,9 @@ contract OzUSDV2ForkTest is TestSetup {
         vm.startPrank(hexTrust);
 
         l2USDX.approve(address(ozUSDV2), _amountB);
+
+        // Grant YIELD_DISTRIBUTOR_ROLE to hexTrust
+        ozUSDV2.grantRole(ozUSDV2.YIELD_DISTRIBUTOR_ROLE(), hexTrust);
 
         vm.expectEmit(true, true, true, true);
         emit OzUSDV2.YieldDistributed(1e18 + _amountA, 1e18 + _amountA + _amountB);
@@ -212,6 +225,9 @@ contract OzUSDV2ForkTest is TestSetup {
         vm.startPrank(hexTrust);
 
         l2USDX.approve(address(ozUSDV2), _amountB);
+
+        // Grant YIELD_DISTRIBUTOR_ROLE to hexTrust
+        ozUSDV2.grantRole(ozUSDV2.YIELD_DISTRIBUTOR_ROLE(), hexTrust);
 
         vm.expectEmit(true, true, true, true);
         emit OzUSDV2.YieldDistributed(1e18 + _amountA, 1e18 + _amountA + _amountB);

--- a/test/L2/OzUSDV2ForkTest.t.sol
+++ b/test/L2/OzUSDV2ForkTest.t.sol
@@ -27,7 +27,7 @@ contract OzUSDV2ForkTest is TestSetup {
     }
 
     function testDeployRevertConditions() public {
-        vm.expectRevert("OzUSD: Must deploy with at least one USDX.");
+        vm.expectRevert(OzUSDV2.InsufficientInitialShares.selector);
         ozUSDV2 = new OzUSDV2(IERC20Metadata(address(l2USDX)), hexTrust, 1e18 - 1);
     }
 


### PR DESCRIPTION
Below is a copy of the interim audit report for those who wish to view it:

[https://docs.google.com/document/d/17WRwF\_TX7BTuBqLJ5FlRb48jCjdgQNQTd8p3KFg2gb8/edit?tab=t.0#heading=h.tak0g6a0asm7](https://docs.google.com/document/d/17WRwF_TX7BTuBqLJ5FlRb48jCjdgQNQTd8p3KFg2gb8/edit?tab=t.0#heading=h.tak0g6a0asm7)

Below are my comments:

---

### **Medium Severity**

1. `bridge()` fails when `bridgeAmount` contains dust — **Fixed. Important finding!**

2. Missing pause checks on user functions — **Won’t fix.**
   Standard ERC4626 does not introduce pause and unpause functionality, as it is not a REQUIRED feature.
   We implemented a pause mechanism specifically for deposit and mint operations, keeping it simple because our intention is to apply pause only to deposit-related actions.

3. Under-collateralized mint when stablecoin depegs — **Won’t fix.**
   The current design accepts the risk of depegging but mitigates potential damage by enforcing per-token `depositCap`.
   This current code was considered an acceptable trade-off between simplicity and risk.
   It seems easier to explain to customer if the exchange ratio is 1:1.

---

### **Low Severity**

1. `OzUSDV2` view functions inconsistent with pause logic — **Fixed.**

2. `lzReceive` gas limit should be adjustable — **Fixed.**

3. Lack of validation that `_amount > 0` in `distributeYield()` — **Fixed.**
   Eventually fixed, though this is more of a nice-to-have. Believed Hex Trust would be unlikely to make this mistake.

4. Misleading comment in `totalAssets()` — **Fixed.**

5. Centralized privilege separation — **Fixed. Only add `YIELD_DISTRIBUTOR_ROLE`.**
   We believe the owner will act benevolently, and introducing multiple roles at this stage would add unnecessary complexity.
   A multi-signature wallet will be introduced in the future to enhance security.

6. Unnecessary `totalAssets()` invocation — **Fixed.**

7. Suboptimal `_getBridgeAmount()` implementation — **Fixed.**

8. Inconsistent `depositCap` decimal units — **Fixed.**
   Strongly agree; this could be borderline between low and medium severity.

9. Missing explicit pause mechanism — **Won’t fix.**
   The absence does not cause harm as we accept 1 stablecoin only, which is USDC.

10. Yield distribution front-running via deposits — **Won’t fix.**
    Frontrunning is acceptable in this case as it does not harm the protocol.

11. Duplicate `MessagingFee` import name causes compilation ambiguity — **Fixed.**

12. Missing `bridgeAmount > 0` validation may burn deposits — **Fixed.**

13. State update after external call enables hypothetical reentrancy — **Fixed.**

14. Generic `require` strings instead of custom errors — **Fixed.**